### PR TITLE
cemu -- allow access to home

### DIFF
--- a/info.cemu.Cemu/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu/info.cemu.Cemu.yml
@@ -14,6 +14,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=dri
+  - --filesystem=home
   - --env=WINEDLLOVERRIDES="mscoree,mshtml="
 
 modules:


### PR DESCRIPTION
This way users can load games from their home.
It's not optimal from a security perspective, but the alternative is for users to have a hard time finding their games. At least until somebody figures out a way to use portals from windows applications.